### PR TITLE
fix typo in man of ict.hausman.test

### DIFF
--- a/R/ict.hausman.test.R
+++ b/R/ict.hausman.test.R
@@ -2,7 +2,7 @@
 
 #' Hausman Specification Test for Two List Experiment Regression Fit Objects
 #'
-#' @param ml Maximum likelihood model fit, for example from ictreg(method = "nls")
+#' @param ml Maximum likelihood model fit, for example from ictreg(method = "ml")
 #' @param nls NLS model fit, for example from ictreg(method = "nls")
 #' @param abs Flag to override error when Hausman statistic is negative, which may indicate misspecification. Set to \code{FALSE} to override.
 #' @param psd Flag to override error when variance-covariance difference is non-positive semidefinite, suggesting misspecification.  Set to \code{TRUE} to override.


### PR DESCRIPTION
Fix typo in the help file of ict.hausman.test